### PR TITLE
Fix GitHub Actions CI: Use Docker Compose v2 syntax

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,6 +31,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       
+    - name: Verify Docker Compose is available
+      run: |
+        docker compose version
+      
     - name: Cache Docker layers
       uses: actions/cache@v4
       with:
@@ -47,19 +51,19 @@ jobs:
     
     - name: Build Docker images
       run: |
-        docker-compose -f docker-compose.test.yml build \
+        docker compose -f docker-compose.test.yml build \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --cache-from type=local,src=/tmp/.buildx-cache \
           --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max
     
     - name: Start test services
       run: |
-        docker-compose -f docker-compose.test.yml up -d mcp-docs-server-test
+        docker compose -f docker-compose.test.yml up -d mcp-docs-server-test
         
     - name: Wait for service health
       run: |
         timeout 180 bash -c '
-          until docker-compose -f docker-compose.test.yml exec -T mcp-docs-server-test curl -f http://localhost:3000/health; do
+          until docker compose -f docker-compose.test.yml exec -T mcp-docs-server-test curl -f http://localhost:3000/health; do
             echo "Waiting for service to be ready..."
             sleep 5
           done
@@ -67,7 +71,7 @@ jobs:
     
     - name: Run integration tests
       run: |
-        docker-compose -f docker-compose.test.yml run --rm integration-tests
+        docker compose -f docker-compose.test.yml run --rm integration-tests
         
     - name: Copy test results
       if: always()
@@ -96,14 +100,14 @@ jobs:
       if: failure()
       run: |
         echo "=== MCP Server Logs ==="
-        docker-compose -f docker-compose.test.yml logs mcp-docs-server-test
+        docker compose -f docker-compose.test.yml logs mcp-docs-server-test
         echo "=== Test Runner Logs ==="
-        docker-compose -f docker-compose.test.yml logs integration-tests
+        docker compose -f docker-compose.test.yml logs integration-tests
         
     - name: Cleanup
       if: always()
       run: |
-        docker-compose -f docker-compose.test.yml down --volumes --remove-orphans
+        docker compose -f docker-compose.test.yml down --volumes --remove-orphans
         docker system prune -f --volumes
         
     - name: Move cache
@@ -158,6 +162,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       
+    - name: Verify Docker Compose is available
+      run: |
+        docker compose version
+      
     - name: Create test secrets
       run: |
         mkdir -p secrets
@@ -166,21 +174,21 @@ jobs:
         
     - name: Build and start services
       run: |
-        docker-compose -f docker-compose.test.yml up -d mcp-docs-server-test
+        docker compose -f docker-compose.test.yml up -d mcp-docs-server-test
         
     - name: Wait for service
       run: |
         timeout 180 bash -c '
-          until docker-compose -f docker-compose.test.yml exec -T mcp-docs-server-test curl -f http://localhost:3000/health; do
+          until docker compose -f docker-compose.test.yml exec -T mcp-docs-server-test curl -f http://localhost:3000/health; do
             sleep 5
           done
         '
         
     - name: Run performance tests
       run: |
-        docker-compose -f docker-compose.test.yml run --rm integration-tests npm run test:integration -- --testNamePattern="Performance"
+        docker compose -f docker-compose.test.yml run --rm integration-tests npm run test:integration -- --testNamePattern="Performance"
         
     - name: Cleanup
       if: always()
       run: |
-        docker-compose -f docker-compose.test.yml down --volumes --remove-orphans
+        docker compose -f docker-compose.test.yml down --volumes --remove-orphans


### PR DESCRIPTION
- Replace 'docker-compose' with 'docker compose' (v2 syntax)
- Remove manual Docker Compose installation (pre-installed on runners)
- GitHub deprecated docker-compose v1 in July 2024
- Resolves CI failures due to command not found errors